### PR TITLE
feat: Add Obsidian Admonition syntax and styling support

### DIFF
--- a/.vitepress/theme/style/main.scss
+++ b/.vitepress/theme/style/main.scss
@@ -233,3 +233,25 @@ a {
     }
   }
 }
+
+//自定义块样式
+.custom-block {
+  .custom-block-content {
+    p, ul, ol, li {
+      color: var(--main-font-color) !important;
+    }
+  }
+
+  &.info, &.warning, &.danger, &.tip, &.summary {
+    .custom-block-content {
+      p, ul, ol, li {
+        color: var(--main-font-color) !important;
+      }
+    }
+  }
+
+  // 标题颜色保持原样
+  .custom-block-title {
+    color: inherit;
+  }
+}

--- a/.vitepress/theme/utils/markdownConfig.mjs
+++ b/.vitepress/theme/utils/markdownConfig.mjs
@@ -80,6 +80,44 @@ const markdownConfig = (md, themeConfig) => {
                 <span class="post-img-tip">${alt}</span>
               </a>`;
   };
+  
+  // obsidian admonition
+  const fence = md.renderer.rules.fence;
+  md.renderer.rules.fence = (...args) => {
+    const [tokens, idx] = args;
+    const token = tokens[idx];
+    const lang = token.info.trim();
+
+    // 处理 Obsidian admonition
+    if (lang.startsWith('ad-')) {
+      const type = lang.substring(3); // 取ad-之后的内容，获取类型
+      const content = token.content;
+
+      const admonitionTypes = {
+        'note': 'info',
+        'question': 'info',
+        'warning': 'warning',
+        'tip': 'tip',
+        'summary': 'info',
+        'hint': 'tip',
+        'important': 'warning',
+        'caution': 'warning',
+        'error': 'danger',
+        'danger': 'danger'
+      };
+
+      const className = admonitionTypes[type] || 'info';
+      const title = type.toUpperCase();
+
+      return `<div class="${className} custom-block">
+            <p class="custom-block-title">${title}</p>
+            <div class="custom-block-content">
+              ${md.render(content)}
+            </div>
+    </div>`;
+    }
+    return fence(...args);
+  };  
 };
 
 export default markdownConfig;


### PR DESCRIPTION
## 功能描述
由于本人使用Obsidian写文章，但是各类Admonition的写法不太一致，故有对Obsidian Admonition语法解析支持的需求。

该PR添加了对 Obsidian Admonition 插件语法的支持，通过对Obsidian Admonition的语法解析为vitepress官方解析后的css类名，使得从 Obsidian 导出的包含 Admonition 语法的笔记可以正确显示。

## 具体改动
1. 在 `markdownConfig.mjs` 中增加了 Admonition 语法解析器
2. 在 `main.scss` 中添加了对应的样式支持，包括：
   - hint 
   - danger/error
   - summary
   - warning
3. 字体颜色是基于`main.scss`继承:root中的颜色，所以不是对所有的Admonition类型都支持。
![image](https://github.com/user-attachments/assets/2c068be5-640d-40b0-a75c-0600f8425871)


## 效果展示
![image](https://github.com/user-attachments/assets/843b89a1-fae3-42c3-9130-9077b5c0940b)

## 测试用例
在任意markdown文件中增加以下内容可以用来测试此功能：
```markdown

```ad-hint
hint
```

```ad-danger
测试danger
```

```ad-error
测试question
```

```ad-summary
**这是内容加粗**
```


```ad-warning
这是代码内容`daima`
```